### PR TITLE
Enable showing slider from outside

### DIFF
--- a/AMSlideOut/AMSlideOutNavigationController.h
+++ b/AMSlideOut/AMSlideOutNavigationController.h
@@ -59,5 +59,6 @@ typedef void (^AMSlideOutCompletionHandler)(void);
 
 - (void)addSectionWithTitle:(NSString*)title;
 - (void)setBadgeValue:(NSString*)value forTag:(int)tag;
+- (void)showSideMenu;
 
 @end


### PR DESCRIPTION
I have a button in my project that needs to show the navigator, this tiny little change adds showSideMenu to the public interface. 
