### PR TITLE
UITextAlignment deprecated

### DIFF
--- a/SlideOutSample/SlideOutSample/AMSlideOut/AMSlideTableCell.m
+++ b/SlideOutSample/SlideOutSample/AMSlideOut/AMSlideTableCell.m
@@ -10,6 +10,11 @@
 #import "AMSlideOutGlobals.h"
 
 #define kMaxImageHeight 44.f
+#ifdef __IPHONE_6_0
+# define kTextAlignmentCenter NSTextAlignmentCenter
+#else
+# define kTextAlignmentCenter UITextAlignmentCenter
+#endif
 
 
 @interface AMSlideTableCell()
@@ -54,7 +59,7 @@
 	self.badge.font = self.options[AMOptionsCellBadgeFont];
 	self.badge.textColor = self.options[AMOptionsCellFontColor];
 	self.badge.adjustsFontSizeToFitWidth = YES;
-	self.badge.textAlignment = UITextAlignmentCenter;
+	self.badge.textAlignment = kTextAlignmentCenter;
 	self.badge.opaque = YES;
 	self.badge.backgroundColor = [UIColor clearColor];
 	self.badge.shadowOffset = CGSizeMake(0, 1);


### PR DESCRIPTION
Changed to NSTextAlignmentCenter for iOS 6.0 and above.
