### PR TITLE
Fixed deprecation warning about using -[NSString sizeWithFont:] in iOS 7

### DIFF
--- a/AMSlideOut/AMSlideTableCell.m
+++ b/AMSlideOut/AMSlideTableCell.m
@@ -73,7 +73,11 @@
 	if (text == nil || [text isEqualToString:@""]) {
 		[self.badge setAlpha:0];
 	} else {
+#ifdef __IPHONE_7_0
+        CGSize fontSize = [text sizeWithAttributes: @{NSFontAttributeName: self.options[AMOptionsCellBadgeFont]}];
+#else
 		CGSize fontSize = [text sizeWithFont:self.options[AMOptionsCellBadgeFont]];
+#endif
 		CGRect badgeFrame = CGRectMake([self.options[AMOptionsBadgePosition] floatValue] - (fontSize.width + 15.0) / 2.0, 12, fontSize.width + 15.0, 20);
 		self.badge.frame = badgeFrame;
 		self.badge.text = text;


### PR DESCRIPTION
Made change so that if this code is being compiled against iOS 7, it uses the recommended -[NSString sizeWithAttributes:] instead.
