### PR TITLE
Slide out table cells always have a white background

### DIFF
--- a/AMSlideOut/AMSlideTableCell.m
+++ b/AMSlideOut/AMSlideTableCell.m
@@ -97,6 +97,8 @@
 
 - (void)drawRect:(CGRect)aRect
 {
+	[self setBackgroundColor: self.options[AMOptionsCellBackground]];
+
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	
 	CGContextSetFillColorWithColor(context, ((UIColor*)self.options[AMOptionsCellBackground]).CGColor);


### PR DESCRIPTION
Slide out table had non-selected cells that always had a white background.  This is now fixed.
