### PR TITLE
Custom table header class using auto layout throws the assertion "Auto L...

### DIFF
--- a/AMSlideOut/AMSlideTableHeader.m
+++ b/AMSlideOut/AMSlideTableHeader.m
@@ -21,6 +21,8 @@
 
 - (void)layoutSubviews
 {
+    [super layoutSubviews];
+    
 	self.titleLabel.backgroundColor = [UIColor clearColor];
 	self.titleLabel.font = self.options[AMOptionsHeaderFont];
 	self.titleLabel.textColor = self.options[AMOptionsHeaderFontColor];


### PR DESCRIPTION
Implementing a custom AMSlideTableHeader using throws the assertion "Auto Layout still required after executing -layoutSubviews" when using auto layout. Adding call to [super layoutSubviews] in AMSlideTableHeader solves this. Not sure if this has any impact on the default AMSlideTableHeader

Signed-off-by: Aniruddha Chitre achitre@chenoainc.com
