### PR TITLE
Added AMOptionsTableInsetX option

### DIFF
--- a/AMSlideOut/AMSlideOutGlobals.h
+++ b/AMSlideOut/AMSlideOutGlobals.h
@@ -51,6 +51,7 @@ FOUNDATION_EXPORT NSString *const AMOptionsUseBorderedButton;
 FOUNDATION_EXPORT NSString *const AMOptionsButtonIcon;
 FOUNDATION_EXPORT NSString *const AMOptionsTableBackground;
 FOUNDATION_EXPORT NSString *const AMOptionsTableOffsetY;
+FOUNDATION_EXPORT NSString *const AMOptionsTableInsetX;
 FOUNDATION_EXPORT NSString *const AMOptionsUseDefaultTitles;
 
 FOUNDATION_EXPORT NSString *const AMOptionsSlideValue;

--- a/AMSlideOut/AMSlideOutGlobals.m
+++ b/AMSlideOut/AMSlideOutGlobals.m
@@ -15,6 +15,7 @@ NSString *const AMOptionsUseBorderedButton = @"AMOptionsUseBorderedButton";
 NSString *const AMOptionsButtonIcon = @"AMOptionsButtonIcon";
 NSString *const AMOptionsTableBackground = @"AMOptionsTableBackground";
 NSString *const AMOptionsTableOffsetY = @"AMOptionsTableOffsetY";
+NSString *const AMOptionsTableInsetX = @"AMOptionsTableInsetX";
 NSString *const AMOptionsUseDefaultTitles = @"AMOptionsUseDefaultTitles";
 NSString *const AMOptionsSlideValue = @"AMOptionsSlideValue";
 NSString *const AMOptionsBackground = @"AMOptionsBackground";
@@ -76,6 +77,7 @@ NSString *const AMOptionsCellBadgeBackColor = @"AMOptionsCellBadgeBackColor";
 	CGFloat offsetY = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0") ? 20.0f : 0.0f;
 	return @{
 			 AMOptionsTableOffsetY : @(offsetY),
+             AMOptionsTableInsetX : @(0),             
 			 AMOptionsEnableGesture : @(YES),
 			 AMOptionsEnableShadow : @(YES),
 			 AMOptionsSetButtonDone : @(NO),
@@ -142,6 +144,7 @@ NSString *const AMOptionsCellBadgeBackColor = @"AMOptionsCellBadgeBackColor";
 	CGFloat offsetY = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0") ? 20.0f : 0.0f;
 	return @{
 			 AMOptionsTableOffsetY : @(offsetY),
+             AMOptionsTableInsetX : @(0),
 			 AMOptionsEnableGesture : @(YES),
 			 AMOptionsEnableShadow : @(YES),
 			 AMOptionsSetButtonDone : @(NO),

--- a/AMSlideOut/AMSlideOutNavigationController.m
+++ b/AMSlideOut/AMSlideOutNavigationController.m
@@ -227,7 +227,7 @@
 	[view setBackgroundColor:self.options[AMOptionsBackground]];
 	
 	// Table View setup
-	self.tableView = [[AMTableView alloc] initWithFrame:CGRectMake(0, [self.options[AMOptionsTableOffsetY] floatValue], [[UIScreen mainScreen] bounds].size.width, [[UIScreen mainScreen] bounds].size.height - 20)];
+	self.tableView = [[AMTableView alloc] initWithFrame:CGRectMake([self.options[AMOptionsTableInsetX] floatValue], [self.options[AMOptionsTableOffsetY] floatValue],[self.options[AMOptionsSlideValue] floatValue]-[self.options[AMOptionsTableInsetX] floatValue]*2, [[UIScreen mainScreen] bounds].size.height - 20)];
 	self.tableView.options = self.options;
 	self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
 	self.tableView.backgroundColor = self.options[AMOptionsBackground];
@@ -564,7 +564,7 @@
 						 // Slide the table
 						 if ([self.options[AMOptionsAnimationSlide] boolValue]) {
 							 CGRect tableFrame = self.tableView.frame;
-							 tableFrame.origin.x = 0;
+							 tableFrame.origin.x = [self.options[AMOptionsTableInsetX] floatValue];
 							 [self.tableView setFrame:tableFrame];
 						 }
 						 

--- a/SlideOutSample/SlideOutSample/AppDelegate.m
+++ b/SlideOutSample/SlideOutSample/AppDelegate.m
@@ -35,6 +35,8 @@
 		   AMOptionsAnimationSlidePercentage: @0.7f,
 		   AMOptionsEnableShadow : @YES,
 		   AMOptionsBadgeShowTotal: @YES,
+           // Want inset cell widths? uncomment and set size of gap that goes on both sides
+           //AMOptionsTableInsetX : @(10),
 		   // Want a custom cell? uncomment and use your own class that inherits from AMSlideTableCell
 		   //AMOptionsTableCellClass: @"CustomCell",
 		   AMOptionsHeaderFont : [UIFont systemFontOfSize:14]


### PR DESCRIPTION
This option insets the tableview width by the given amount on both sides.  
Includes default value of 0 for backwards compatibility.

Example image attached.
![insettableexample](https://f.cloud.github.com/assets/2762398/1432742/96d306f4-40e3-11e3-86d0-b29498c8101e.png)
