### PR TITLE
add navigationController as childVC so it's notified of view changes

### DIFF
--- a/AMSlideOut/AMSlideOutNavigationController.m
+++ b/AMSlideOut/AMSlideOutNavigationController.m
@@ -597,6 +597,7 @@
     [view addSubview:self.darkView];
 	[view addSubview:self.contentController.view];
 	
+    [self addChildViewController:self.contentController];
 	self.view = view;
 }
 


### PR DESCRIPTION
Even when you're using a custom navigation controller, it isn't notified of certain changes, e.g. size changes, due to the fact that it isn't a child view controller of the SlideoutNavicationController.

(in part) fixes #80 
