### PR TITLE
Fix issue where default menu icon was not found

### DIFF
--- a/AMSlideOut/AMSlideOutGlobals.m
+++ b/AMSlideOut/AMSlideOutGlobals.m
@@ -81,6 +81,8 @@ NSString *const AMOptionsNavBarHidden = @"AMOptionsNavBarHidden";
 
 + (NSDictionary*)defaultOptions
 {
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    
 	CGFloat offsetY = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0") ? 20.0f : 0.0f;
 	return @{
 			 AMOptionsTableOffsetY : @(offsetY),
@@ -90,7 +92,7 @@ NSString *const AMOptionsNavBarHidden = @"AMOptionsNavBarHidden";
 			 AMOptionsEnableShadow : @(YES),
 			 AMOptionsSetButtonDone : @(NO),
 			 AMOptionsUseBorderedButton : @(NO),
-			 AMOptionsButtonIcon : [UIImage imageNamed:@"iconSlide.png"],
+			 AMOptionsButtonIcon : [UIImage imageNamed:@"iconSlide" inBundle:bundle compatibleWithTraitCollection:nil],
 			 AMOptionsUseDefaultTitles : @(YES),
 			 AMOptionsSlideValue : @(270),
 			 AMOptionsBackground : [UIColor colorWithRed:0.19 green:0.22 blue:0.29 alpha:1.0],


### PR DESCRIPTION
Under Xcode 7 and iOS 9, in `AMSlideOutGlobals.m: + (NSDictionary*)defaultOptions`, `[UIImage imageNamed:@"iconSlide.png"]` was returning `nil`, so I changed this code to load the `iconSlide.png` image from a specific bundle, which seems to have fixed the issue for me.

The Sample project is also no currently building under Xcode 7. Any plans to update the project to the latest?