### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 AMSlideOutNavigationController
 ==================
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/AMSlideOutController/badge.png)](http://beta.cocoapods.org/?q=amslideoutcontroller)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/AMSlideOutController/badge.png)](http://beta.cocoapods.org/?q=amslideoutcontroller)
 [![Build Status](https://travis-ci.org/andreamazz/SlideOutNavigation.png)](https://travis-ci.org/andreamazz/SlideOutNavigation) 
 [![Analytics](https://ga-beacon.appspot.com/UA-42282237-8/AMSlideOutController/README)](https://github.com/igrigorik/ga-beacon)
 
@@ -16,7 +16,7 @@ Screenshot
 ![AMSlideOutNavigationController](https://raw.githubusercontent.com/andreamazz/SlideOutNavigation/master/screenshot.png)
 
 
-Setup with Cocoapods
+Setup with CocoaPods
 --------------------
 * Add ```pod 'AMSlideOutController'``` to your Podfile
 * Run ```pod install```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
